### PR TITLE
gx: update go-datastore, go-ds-badger

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.4: QmPP91WFAb8LCs8EMzGvDPPvg1kacbqRkoxgTTnUsZckGe
+1.1.5: QmTLGdJpFxjNTGqBkwTyhN3WeJteSjQPACmyxDjJ49V5NM

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   "gxDependencies": [
     {
       "author": "jbenet",
-      "hash": "QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG",
+      "hash": "QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5",
       "name": "go-datastore",
-      "version": "1.2.2"
+      "version": "1.4.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdQRoFgg8jTNP5NLn6AuTgpEnDhwkVdBPEBUSTtPiY2yQ",
+      "hash": "QmWpcmY1DgPxKwMq3MWxxYx7QH61pfeQHQZSPqHjhwqT6t",
       "name": "failstore",
-      "version": "1.0.4"
+      "version": "1.0.5"
     }
   ],
   "gxVersion": "0.8.0",
@@ -25,6 +25,6 @@
   "license": "",
   "name": "retry-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.4"
+  "version": "1.1.5"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/whyrusleeping/failstore/pull/6


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace